### PR TITLE
Add support of EXTGRP tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-playlist-parser",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iptv-playlist-parser",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A basic IPTV playlist parser",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ Parser.parse = (content) => {
         url: line.getAttribute('tvg-url'),
       },
       group: {
-        title: line.getAttribute('group-title'),
+        title: line.getAttribute('group-title') || line.getGroup(),
       },
       http: {
         referrer: line.getVlcOption('http-referrer'),
@@ -79,8 +79,17 @@ String.prototype.getVlcOption = function (name) {
   return match && match[1] ? match[1] : ''
 }
 
+String.prototype.getGroup = function () {
+  const groupTag = '#EXTGRP'
+  const groupLine = this.split('\n')
+  .filter((l) => l.startsWith(groupTag))
+  .shift()
+
+  return groupLine ? groupLine.split(':')[1] : ''
+}
+
 String.prototype.getURL = function () {
-  const supportedTags = ['#EXTVLCOPT', '#EXTINF']
+  const supportedTags = ['#EXTVLCOPT', '#EXTINF', '#EXTGRP']
   const last = this.split('\n')
     .filter((l) => l)
     .map((l) => l.trim())

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ Parser.parse = (content) => {
         url: line.getAttribute('tvg-url'),
       },
       group: {
-        title: line.getAttribute('group-title') || line.getGroup(),
+        title: line.getGroup() || line.getAttribute('group-title'),
       },
       http: {
         referrer: line.getVlcOption('http-referrer'),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,7 +158,7 @@ http://cdn-hls.globecast.tv/live/ramdisk/tamazight_tv8_snrt/hls_snrt/index.m3u8
 it('could parse playlist with #EXTGRP tag', () => {
   const playlist = `
 #EXTM3U
-#EXTINF:0 tvg-name="TestChannel",Test Channel
+#EXTINF:0 tvg-name="TestChannel" group-title="Entertainment",Test Channel
 #EXTGRP:News
 http://test.channel.com/iptv/secret/1/index.m3u8`;
 
@@ -188,7 +188,7 @@ http://test.channel.com/iptv/secret/1/index.m3u8`;
           },
           url: 'http://test.channel.com/iptv/secret/1/index.m3u8',
           raw:
-            '#EXTINF:0 tvg-name="TestChannel",Test Channel\n#EXTGRP:News\nhttp://test.channel.com/iptv/secret/1/index.m3u8'
+            '#EXTINF:0 tvg-name="TestChannel" group-title="Entertainment",Test Channel\n#EXTGRP:News\nhttp://test.channel.com/iptv/secret/1/index.m3u8'
         }
       ]
     })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -154,3 +154,42 @@ http://cdn-hls.globecast.tv/live/ramdisk/tamazight_tv8_snrt/hls_snrt/index.m3u8
     ]
   })
 })
+
+it('could parse playlist with #EXTGRP tag', () => {
+  const playlist = `
+#EXTM3U
+#EXTINF:0 tvg-name="TestChannel",Test Channel
+#EXTGRP:News
+http://test.channel.com/iptv/secret/1/index.m3u8`;
+
+    expect(parser.parse(playlist)).toStrictEqual({
+      header: {
+        attrs: {},
+        raw:
+          '#EXTM3U'
+      },
+      items: [
+        {
+          name: 'Test Channel',
+          tvg: {
+            id: '',
+            name: 'TestChannel',
+            language: '',
+            country: '',
+            logo: '',
+            url: ''
+          },
+          group: {
+            title: 'News'
+          },
+          http: {
+            referrer: '',
+            'user-agent': ''
+          },
+          url: 'http://test.channel.com/iptv/secret/1/index.m3u8',
+          raw:
+            '#EXTINF:0 tvg-name="TestChannel",Test Channel\n#EXTGRP:News\nhttp://test.channel.com/iptv/secret/1/index.m3u8'
+        }
+      ]
+    })
+})


### PR DESCRIPTION
This PR adds support for #EXTGRP tag, which is part of some iptv playlists and contains infromation about group of a channel.