### PR TITLE
Add support of catchup and timeshift attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Input:
 
 ```
 #EXTM3U x-tvg-url="http://example.com/epg.xml.gz"
-#EXTINF:-1 tvg-id="cnn.us" tvg-name="CNN" tvg-language="English" tvg-country="US" tvg-url="http://195.154.221.171/epg/guide.xml.gz" tvg-logo="http://example.com/logo.png" group-title="News",CNN (US)
+#EXTINF:-1 tvg-id="cnn.us" tvg-name="CNN" tvg-language="English" tvg-country="US" tvg-url="http://195.154.221.171/epg/guide.xml.gz" timeshift="3" catchup="shift" catchup-days="3" catchup-source="https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324" tvg-logo="http://example.com/logo.png" group-title="News",CNN (US)
 #EXTGRP:News
 #EXTVLCOPT:http-referrer=http://example.com/
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5)
@@ -62,7 +62,13 @@ Output:
         'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5)'
       },
       url: 'http://example.com/stream.m3u8',
-      raw: '#EXTINF:-1 tvg-id="cnn.us" tvg-name="CNN" tvg-language="English" tvg-country="US" tvg-url="http://195.154.221.171/epg/guide.xml.gz" tvg-logo="http://example.com/logo.png" group-title="News",CNN (US)\n#EXTVLCOPT:http-referrer=http://example.com/\n#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5)\nhttp://example.com/stream.m3u8'
+      raw: '#EXTINF:-1 tvg-id="cnn.us" tvg-name="CNN" tvg-language="English" tvg-country="US" tvg-url="http://195.154.221.171/epg/guide.xml.gz" tvg-logo="http://example.com/logo.png" group-title="News",CNN (US)\n#EXTVLCOPT:http-referrer=http://example.com/\n#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5)\nhttp://example.com/stream.m3u8',
+      timeshift: '3',
+      catchup: {
+        type: 'shift',
+        source: 'https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324',
+        days: '3'
+      }
     }
   ]
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,33 +1,45 @@
 declare module 'iptv-playlist-parser'
 
-export function parse(
-  content: string
-): {
-  header: {
-    attrs: {
-      'x-tvg-url': string
-    }
-    raw: string
+export interface PlaylistHeader {
+  attrs: {
+    'x-tvg-url': string
   }
-  items: {
-    name: string
-    tvg: {
-      id: string
-      name: string
-      language: string
-      country: string
-      url: string
-      logo: string,
-      rec: string
-    }
-    group: {
-      title: string
-    }
-    http: {
-      referrer: string
-      'user-agent': string
-    }
-    url: string
-    raw: string
-  }[]
+  raw: string
 }
+
+export interface PlaylistItemTvg {
+  id: string
+  name: string
+  language: string
+  country: string
+  url: string
+  logo: string
+  rec: string
+}
+
+export interface PlaylistItem {
+  name: string
+  tvg: PlaylistItemTvg
+  group: {
+    title: string
+  }
+  http: {
+    referrer: string
+    'user-agent': string
+  }
+  url: string
+  raw: string
+  timeshift: '',
+  catchup: {
+    type: '',
+    source: '',
+    days: ''
+  }
+}
+
+export interface Playlist {
+  header: PlaylistHeader
+  items: PlaylistItem[]
+}
+
+export function parse(content: string): Playlist

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,13 @@ Parser.parse = content => {
         'user-agent': line.getVlcOption('http-user-agent')
       },
       url: line.getURL(),
-      raw: line
+      raw: line,
+      catchup: {
+        type: line.getAttribute('catchup'),
+        days: line.getAttribute('catchup-days'),
+        source: line.getAttribute('catchup-source')
+      },
+      timeshift: line.getAttribute('timeshift')
     }
 
     playlist.items.push(item)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,7 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
           logo:
             'http://www.rtvchannel.com.au/wp-content/uploads/2017/04/xshow_08.png,Mic_.2KNN9OHw1p.png.pagespeed.ce.2KNN9OHw1p.png',
           url: 'http://195.154.221.171/epg/guide.xml.gz',
-          rec: "3"
+          rec: '3'
         },
         group: {
           title: 'Только Android'
@@ -52,12 +52,12 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
         url: 'http://livestream.htp.tv/hls-live/livepkgr/_definst_/H1/H1_HQ.m3u8',
         raw:
           '#EXTINF:-1 tvg-ID="CH1" tvg-name="Ch 1" tvg-language="English" tvg-country="US" tvg-logo="http://www.rtvchannel.com.au/wp-content/uploads/2017/04/xshow_08.png,Mic_.2KNN9OHw1p.png.pagespeed.ce.2KNN9OHw1p.png" tvg-url="http://195.154.221.171/epg/guide.xml.gz" tvg-rec="3" group-title="Music",Channel 1 (Tested)\n    #EXTGRP:Только Android\n    #EXTVLCOPT:http-referrer=http://player.livesports.pw/la2/\n    #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.25 Safari/537.36\n    http://livestream.htp.tv/hls-live/livepkgr/_definst_/H1/H1_HQ.m3u8',
-          timeshift: '',
-          catchup: {
-            type: '',
-            source: '',
-            days: ''
-          }
+        timeshift: '',
+        catchup: {
+          type: '',
+          source: '',
+          days: ''
+        }
       },
       {
         name: 'Channel 2',
@@ -80,11 +80,11 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
         url: 'stream/chunklist.m3u8',
         raw: `#EXTINF:16 tvg-id="CH2",Channel 2\nstream/chunklist.m3u8\n\n=========================sudan===================================\n#EXTM3U`,
         timeshift: '',
-          catchup: {
-            type: '',
-            source: '',
-            days: ''
-          }
+        catchup: {
+          type: '',
+          source: '',
+          days: ''
+        }
       },
       {
         name: '=>(★ TURKİYE ★)<=',
@@ -107,11 +107,11 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
         url: 'http://wodpro24.tr4545.in:8080/expred/peru8k.mp4',
         raw: `#EXTINF:1,=>(★ TURKİYE ★)<=\n\nhttp://wodpro24.tr4545.in:8080/expred/peru8k.mp4`,
         timeshift: '',
-          catchup: {
-            type: '',
-            source: '',
-            days: ''
-          }
+        catchup: {
+          type: '',
+          source: '',
+          days: ''
+        }
       },
       {
         name: 'TRT 1 HD',
@@ -135,11 +135,11 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
           "https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(ow4)m(U1zbeMZOcvuVp_PjPC5VeA)n(a(-xL_Aw)s(yeg)'a(vuk2sg)s(3Rc)))s(s(2h8)b(OVsX9brZ0psZeMaQYt9O46THOxFsPHFB6R_YrLO_lAYLehFKlBcB3utUOhZjyWY7C52ngNY4Ow9Ook29TA)'s(gRY)b(iE9B80a6sOKUZn0UnLJQU_bKwqIDP29GWBxvJz1bQ1ihEmrOuDaUGTinW0l8unt4U9_v4jCwiAC2T6TOa8pgVRIAfsnYG9Y7VoI5EmwQ)'s(A4Q)b(ayZ0dwLn))m(0))/index.m3u8",
         raw: `#EXTINF:1 timeshift="3" catchup="shift" catchup-days="3" catchup-source="https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324",TRT 1 HD\nhttps://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(ow4)m(U1zbeMZOcvuVp_PjPC5VeA)n(a(-xL_Aw)s(yeg)'a(vuk2sg)s(3Rc)))s(s(2h8)b(OVsX9brZ0psZeMaQYt9O46THOxFsPHFB6R_YrLO_lAYLehFKlBcB3utUOhZjyWY7C52ngNY4Ow9Ook29TA)'s(gRY)b(iE9B80a6sOKUZn0UnLJQU_bKwqIDP29GWBxvJz1bQ1ihEmrOuDaUGTinW0l8unt4U9_v4jCwiAC2T6TOa8pgVRIAfsnYG9Y7VoI5EmwQ)'s(A4Q)b(ayZ0dwLn))m(0))/index.m3u8`,
         timeshift: '3',
-          catchup: {
-            type: 'shift',
-            source: 'https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324',
-            days: '3'
-          }
+        catchup: {
+          type: 'shift',
+          source: 'https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324',
+          days: '3'
+        }
       },
       {
         name: ' name',
@@ -162,11 +162,11 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
         url: 'http://100.101.102.103:1000/index.m3u8',
         raw: `#EXTINF: -1, name\r\nhttp://100.101.102.103:1000/index.m3u8`,
         timeshift: '',
-          catchup: {
-            type: '',
-            source: '',
-            days: ''
-          }
+        catchup: {
+          type: '',
+          source: '',
+          days: ''
+        }
       }
     ]
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,7 @@ stream/chunklist.m3u8
 #EXTINF:1,=>(★ TURKİYE ★)<=
 
 http://wodpro24.tr4545.in:8080/expred/peru8k.mp4
-#EXTINF:1,TRT 1 HD
+#EXTINF:1 timeshift="3" catchup="shift" catchup-days="3" catchup-source="https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324",TRT 1 HD
 https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(ow4)m(U1zbeMZOcvuVp_PjPC5VeA)n(a(-xL_Aw)s(yeg)'a(vuk2sg)s(3Rc)))s(s(2h8)b(OVsX9brZ0psZeMaQYt9O46THOxFsPHFB6R_YrLO_lAYLehFKlBcB3utUOhZjyWY7C52ngNY4Ow9Ook29TA)'s(gRY)b(iE9B80a6sOKUZn0UnLJQU_bKwqIDP29GWBxvJz1bQ1ihEmrOuDaUGTinW0l8unt4U9_v4jCwiAC2T6TOa8pgVRIAfsnYG9Y7VoI5EmwQ)'s(A4Q)b(ayZ0dwLn))m(0))/index.m3u8
 #EXTINF: -1, name\r\nhttp://100.101.102.103:1000/index.m3u8\r\n
   `
@@ -51,7 +51,13 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
         },
         url: 'http://livestream.htp.tv/hls-live/livepkgr/_definst_/H1/H1_HQ.m3u8',
         raw:
-          '#EXTINF:-1 tvg-ID="CH1" tvg-name="Ch 1" tvg-language="English" tvg-country="US" tvg-logo="http://www.rtvchannel.com.au/wp-content/uploads/2017/04/xshow_08.png,Mic_.2KNN9OHw1p.png.pagespeed.ce.2KNN9OHw1p.png" tvg-url="http://195.154.221.171/epg/guide.xml.gz" tvg-rec="3" group-title="Music",Channel 1 (Tested)\n    #EXTGRP:Только Android\n    #EXTVLCOPT:http-referrer=http://player.livesports.pw/la2/\n    #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.25 Safari/537.36\n    http://livestream.htp.tv/hls-live/livepkgr/_definst_/H1/H1_HQ.m3u8'
+          '#EXTINF:-1 tvg-ID="CH1" tvg-name="Ch 1" tvg-language="English" tvg-country="US" tvg-logo="http://www.rtvchannel.com.au/wp-content/uploads/2017/04/xshow_08.png,Mic_.2KNN9OHw1p.png.pagespeed.ce.2KNN9OHw1p.png" tvg-url="http://195.154.221.171/epg/guide.xml.gz" tvg-rec="3" group-title="Music",Channel 1 (Tested)\n    #EXTGRP:Только Android\n    #EXTVLCOPT:http-referrer=http://player.livesports.pw/la2/\n    #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.25 Safari/537.36\n    http://livestream.htp.tv/hls-live/livepkgr/_definst_/H1/H1_HQ.m3u8',
+          timeshift: '',
+          catchup: {
+            type: '',
+            source: '',
+            days: ''
+          }
       },
       {
         name: 'Channel 2',
@@ -72,7 +78,13 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
           'user-agent': ''
         },
         url: 'stream/chunklist.m3u8',
-        raw: `#EXTINF:16 tvg-id="CH2",Channel 2\nstream/chunklist.m3u8\n\n=========================sudan===================================\n#EXTM3U`
+        raw: `#EXTINF:16 tvg-id="CH2",Channel 2\nstream/chunklist.m3u8\n\n=========================sudan===================================\n#EXTM3U`,
+        timeshift: '',
+          catchup: {
+            type: '',
+            source: '',
+            days: ''
+          }
       },
       {
         name: '=>(★ TURKİYE ★)<=',
@@ -93,7 +105,13 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
           'user-agent': ''
         },
         url: 'http://wodpro24.tr4545.in:8080/expred/peru8k.mp4',
-        raw: `#EXTINF:1,=>(★ TURKİYE ★)<=\n\nhttp://wodpro24.tr4545.in:8080/expred/peru8k.mp4`
+        raw: `#EXTINF:1,=>(★ TURKİYE ★)<=\n\nhttp://wodpro24.tr4545.in:8080/expred/peru8k.mp4`,
+        timeshift: '',
+          catchup: {
+            type: '',
+            source: '',
+            days: ''
+          }
       },
       {
         name: 'TRT 1 HD',
@@ -115,7 +133,13 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
         },
         url:
           "https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(ow4)m(U1zbeMZOcvuVp_PjPC5VeA)n(a(-xL_Aw)s(yeg)'a(vuk2sg)s(3Rc)))s(s(2h8)b(OVsX9brZ0psZeMaQYt9O46THOxFsPHFB6R_YrLO_lAYLehFKlBcB3utUOhZjyWY7C52ngNY4Ow9Ook29TA)'s(gRY)b(iE9B80a6sOKUZn0UnLJQU_bKwqIDP29GWBxvJz1bQ1ihEmrOuDaUGTinW0l8unt4U9_v4jCwiAC2T6TOa8pgVRIAfsnYG9Y7VoI5EmwQ)'s(A4Q)b(ayZ0dwLn))m(0))/index.m3u8",
-        raw: `#EXTINF:1,TRT 1 HD\nhttps://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(ow4)m(U1zbeMZOcvuVp_PjPC5VeA)n(a(-xL_Aw)s(yeg)'a(vuk2sg)s(3Rc)))s(s(2h8)b(OVsX9brZ0psZeMaQYt9O46THOxFsPHFB6R_YrLO_lAYLehFKlBcB3utUOhZjyWY7C52ngNY4Ow9Ook29TA)'s(gRY)b(iE9B80a6sOKUZn0UnLJQU_bKwqIDP29GWBxvJz1bQ1ihEmrOuDaUGTinW0l8unt4U9_v4jCwiAC2T6TOa8pgVRIAfsnYG9Y7VoI5EmwQ)'s(A4Q)b(ayZ0dwLn))m(0))/index.m3u8`
+        raw: `#EXTINF:1 timeshift="3" catchup="shift" catchup-days="3" catchup-source="https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324",TRT 1 HD\nhttps://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(ow4)m(U1zbeMZOcvuVp_PjPC5VeA)n(a(-xL_Aw)s(yeg)'a(vuk2sg)s(3Rc)))s(s(2h8)b(OVsX9brZ0psZeMaQYt9O46THOxFsPHFB6R_YrLO_lAYLehFKlBcB3utUOhZjyWY7C52ngNY4Ow9Ook29TA)'s(gRY)b(iE9B80a6sOKUZn0UnLJQU_bKwqIDP29GWBxvJz1bQ1ihEmrOuDaUGTinW0l8unt4U9_v4jCwiAC2T6TOa8pgVRIAfsnYG9Y7VoI5EmwQ)'s(A4Q)b(ayZ0dwLn))m(0))/index.m3u8`,
+        timeshift: '3',
+          catchup: {
+            type: 'shift',
+            source: 'https://m3u-server/hls-apple-s4-c494-abcdef.m3u8?utc=325234234&lutc=3123125324',
+            days: '3'
+          }
       },
       {
         name: ' name',
@@ -136,7 +160,13 @@ https://video-rvd-lmg.rnp.br/live/ocp(t(FfZfeFx3QG4)r(TOqkzw)a(ut273w)p(d(lCo)k(
           'user-agent': ''
         },
         url: 'http://100.101.102.103:1000/index.m3u8',
-        raw: `#EXTINF: -1, name\r\nhttp://100.101.102.103:1000/index.m3u8`
+        raw: `#EXTINF: -1, name\r\nhttp://100.101.102.103:1000/index.m3u8`,
+        timeshift: '',
+          catchup: {
+            type: '',
+            source: '',
+            days: ''
+          }
       }
     ]
   })
@@ -177,7 +207,13 @@ http://cdn-hls.globecast.tv/live/ramdisk/tamazight_tv8_snrt/hls_snrt/index.m3u8
         },
         url: 'http://cdn-hls.globecast.tv/live/ramdisk/tamazight_tv8_snrt/hls_snrt/index.m3u8',
         raw:
-          '#EXTINF:-1,tamazight tv8\nhttp://cdn-hls.globecast.tv/live/ramdisk/tamazight_tv8_snrt/hls_snrt/index.m3u8'
+          '#EXTINF:-1,tamazight tv8\nhttp://cdn-hls.globecast.tv/live/ramdisk/tamazight_tv8_snrt/hls_snrt/index.m3u8',
+        timeshift: '',
+        catchup: {
+          type: '',
+          source: '',
+          days: ''
+        }
       }
     ]
   })
@@ -217,7 +253,13 @@ http://test.channel.com/iptv/secret/1/index.m3u8`
         },
         url: 'http://test.channel.com/iptv/secret/1/index.m3u8',
         raw:
-          '#EXTINF:0 tvg-name="TestChannel" group-title="Entertainment",Test Channel\n#EXTGRP:News\n#EXTVLCOPT:http-user-agent="Dalvik/2.1.0 (Linux; U; Android 6.0.1;)"\nhttp://test.channel.com/iptv/secret/1/index.m3u8'
+          '#EXTINF:0 tvg-name="TestChannel" group-title="Entertainment",Test Channel\n#EXTGRP:News\n#EXTVLCOPT:http-user-agent="Dalvik/2.1.0 (Linux; U; Android 6.0.1;)"\nhttp://test.channel.com/iptv/secret/1/index.m3u8',
+        timeshift: '',
+        catchup: {
+          type: '',
+          source: '',
+          days: ''
+        }
       }
     ]
   })


### PR DESCRIPTION
This PR adds support of `catchup`, `catchup-days`, `catchup-source`, and `timeshift` attributes that are used in some playlists. In addition, the TypeScript definitions have been adapted and improved.